### PR TITLE
Systemd: Fix startup when using systemd

### DIFF
--- a/package/kodi/kodi.service
+++ b/package/kodi/kodi.service
@@ -3,10 +3,12 @@ Description = Kodi Entertainment Center
 After = network.target
 
 [Service]
+User = root
+Group = root
 Type = simple
+PIDFile = /var/run/kodi.pid
 ExecStart = /usr/lib/kodi/kodi.bin --standalone -fs -n
 Restart = on-failure
 
 [Install]
 WantedBy = multi-user.target
-


### PR DESCRIPTION
When using systemd, Kodi needs a user to startup, otherwise it stays in a startup-loop!

Signed-off-by: Guido Lipke <lipkegu1810@gmail.com>